### PR TITLE
Initial commit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ catkin_simple()
 
 include(ExternalProject)
 
-
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/mono-2.0)
 
 set(MONO_VERSION 5.4.1.7)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(mono_catkin)
+
+find_package(catkin_simple REQUIRED)
+catkin_simple()
+
+include(ExternalProject)
+
+
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/mono-2.0)
+
+set(MONO_VERSION 5.4.1.7)
+ExternalProject_Add(mono_src
+  GIT_REPOSITORY git@github.com:mono/mono.git
+  GIT_TAG mono-${MONO_VERSION}
+  UPDATE_COMMAND ""
+  CONFIGURE_COMMAND
+    cd ../mono_src/
+    && ./autogen.sh
+    --prefix=${CATKIN_DEVEL_PREFIX}
+  BUILD_COMMAND
+    cd ../mono_src/
+    && $(MAKE)
+  INSTALL_COMMAND
+    cd ../mono_src/
+    && $(MAKE) install
+)
+
+cs_add_library(${PROJECT_NAME} src/dependency_tracker.cc)
+add_dependencies(${PROJECT_NAME} mono_src)
+target_link_libraries(${PROJECT_NAME} ${CATKIN_DEVEL_PREFIX}/lib/libmono-2.0${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+cs_install()
+
+cs_export(
+  INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include/mono-2.0
+  LIBRARIES ${CATKIN_DEVEL_PREFIX}/lib/libmono-2.0${CMAKE_SHARED_LIBRARY_SUFFIX}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,11 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/mono-2.0)
 
 set(MONO_VERSION 5.4.1.7)
 ExternalProject_Add(mono_src
-  GIT_REPOSITORY git@github.com:mono/mono.git
-  GIT_TAG mono-${MONO_VERSION}
+  URL https://download.mono-project.com/sources/mono/mono-${MONO_VERSION}.tar.bz2
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND
     cd ../mono_src/
-    && ./autogen.sh
+    && ./configure
     --prefix=${CATKIN_DEVEL_PREFIX}
   BUILD_COMMAND
     cd ../mono_src/

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,11 @@
+<package>
+  <name>mono_catkin</name>
+  <version>5.4.1</version>
+  <description>Catkin wrapper for Mono.</description>
+  <maintainer email="brik@ethz.ch">Rik Bähnemann</maintainer>
+
+  <license>See package</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin_simple</buildtool_depend>
+</package>


### PR DESCRIPTION
Pull and build mono version 5.4.1.7.

@helenol , do you know how to suppress gcc warnings? Currently the build outputs 100s of warning lines.